### PR TITLE
Use default prefix length of 64 for ipv6, when none is present

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func verifyCorrection(correction []string, db *geoip2.Reader) (int, error) {
 	networkOrIP := correction[0]
 	if !(strings.Contains(networkOrIP, "/")) {
 		if strings.Contains(networkOrIP, ":") {
-			networkOrIP += "/128"
+			networkOrIP += "/64"
 		} else {
 			networkOrIP += "/32"
 		}


### PR DESCRIPTION
- /64 is a typical allocation for an end user, not /128