### PR TITLE
Move ProcessGeofeed to 'verify' sub-package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## CHANGELOG
 
+## 2.2.1 (2023-03-09)
+
+* Moved ProcessGeofeed to `verify` sub-package.
+
+## 2.2.0 (2022-08-29)
+
+* Update to Go version 1.18
+
 ## 2.1.0 (2021-06-16)
 
 * Fix handling of extra fields (reported by Raiko Wielk)

--- a/main.go
+++ b/main.go
@@ -10,35 +10,24 @@ package main
 
 import (
 	"bytes"
-	"encoding/csv"
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"log"
-	"net"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
-	"github.com/TomOnTime/utfutil"
-
-	geoip2 "github.com/oschwald/geoip2-golang"
+	"github.com/maxmind/mm-geofeed-verifier/verify"
 )
 
-const version = "2.2.0"
+const version = "2.2.1"
 
 type config struct {
 	gf      string
 	db      string
 	isp     string
 	version bool
-}
-
-type counts struct {
-	total       int
-	differences int
 }
 
 func main() {
@@ -55,7 +44,7 @@ func run() error {
 		return err
 	}
 
-	c, diffLines, asnCounts, err := processGeofeed(conf.gf, conf.db, conf.isp)
+	c, diffLines, asnCounts, err := verify.ProcessGeofeed(conf.gf, conf.db, conf.isp)
 	if err != nil {
 		return err
 	}
@@ -63,8 +52,8 @@ func run() error {
 	fmt.Printf(
 		strings.Join(diffLines, "\n\n")+
 			"\n\nOut of %d potential corrections, %d may be different than our current mappings\n\n",
-		c.total,
-		c.differences,
+		c.Total,
+		c.Differences,
 	)
 
 	// https://stackoverflow.com/a/56706305
@@ -128,231 +117,4 @@ func parseFlags(program string, args []string) (c *config, output string, err er
 	}
 
 	return &conf, buf.String(), nil
-}
-
-func processGeofeed(geofeedFilename, mmdbFilename, ispFilename string) (counts, []string, map[uint]int, error) {
-	var c counts
-	var diffLines []string
-	geofeedFH, err := utfutil.OpenFile(filepath.Clean(geofeedFilename), utfutil.UTF8)
-	if err != nil {
-		return c, diffLines, nil, err
-	}
-	defer func() {
-		if err := geofeedFH.Close(); err != nil {
-			log.Println(err)
-		}
-	}()
-
-	db, err := geoip2.Open(filepath.Clean(mmdbFilename))
-	if err != nil {
-		return c, diffLines, nil, err
-	}
-	defer db.Close()
-
-	var ispdb *geoip2.Reader
-	if len(ispFilename) > 0 {
-		ispdb, err = geoip2.Open(filepath.Clean(ispFilename))
-		if err != nil {
-			return c, diffLines, nil, err
-		}
-		defer ispdb.Close()
-	}
-	asnCounts := make(map[uint]int)
-
-	csvReader := csv.NewReader(geofeedFH)
-	csvReader.ReuseRecord = true
-	csvReader.Comment = '#'
-	csvReader.FieldsPerRecord = -1
-	csvReader.TrimLeadingSpace = true
-
-	const expectedFieldsPerRecord = 5
-
-	rowCount := 0
-
-	for {
-		row, err := csvReader.Read()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		rowCount++
-		if err != nil {
-			return c, diffLines, asnCounts, err
-		}
-		if len(row) < expectedFieldsPerRecord {
-			return c, nil, nil, fmt.Errorf(
-				"saw fewer than the expected %d fields at line %d",
-				expectedFieldsPerRecord,
-				rowCount,
-			)
-		}
-
-		c.total++
-		diffLine, err := verifyCorrection(row[:expectedFieldsPerRecord], db, ispdb, asnCounts)
-		if err != nil {
-			return c, diffLines, asnCounts, err
-		}
-
-		if len(diffLine) > 0 {
-			diffLines = append(diffLines, diffLine)
-			c.differences++
-		}
-	}
-	if err != nil && !errors.Is(err, io.EOF) {
-		return c, diffLines, asnCounts, err
-	}
-	return c, diffLines, asnCounts, nil
-}
-
-func verifyCorrection(correction []string, db, ispdb *geoip2.Reader, asnCounts map[uint]int) (string, error) {
-	/*
-	   0: network (CIDR or single IP)
-	   1: ISO-3166 country code
-	   2: ISO-3166-2 region code
-	   3: city name
-	   4: postal code
-	*/
-
-	for i, v := range correction {
-		correction[i] = strings.TrimSpace(v)
-	}
-
-	networkOrIP := correction[0]
-	if networkOrIP == "" {
-		return "", errors.New("network field is empty")
-	}
-	if !(strings.Contains(networkOrIP, "/")) {
-		if strings.Contains(networkOrIP, ":") {
-			networkOrIP += "/64"
-		} else {
-			networkOrIP += "/32"
-		}
-	}
-	network, _, err := net.ParseCIDR(networkOrIP)
-	if err != nil {
-		return "", err
-	}
-
-	mmdbRecord, err := db.City(network)
-	if err != nil {
-		return "", err
-	}
-
-	firstSubdivision := ""
-	if len(mmdbRecord.Subdivisions) > 0 {
-		firstSubdivision = mmdbRecord.Subdivisions[0].IsoCode
-	}
-	// ISO-3166-2 region codes are prefixed with the ISO country code,
-	// but we accept just the region code part
-	if strings.Contains(correction[2], "-") {
-		firstSubdivision = mmdbRecord.Country.IsoCode + "-" + firstSubdivision
-	}
-
-	asNumber := uint(0)
-	asName := ""
-	ispName := ""
-	if ispdb != nil {
-		ispRecord, err := ispdb.ISP(network)
-		if err != nil {
-			return "", err
-		}
-		asNumber = ispRecord.AutonomousSystemNumber
-		asName = ispRecord.AutonomousSystemOrganization
-		ispName = ispRecord.ISP
-	}
-	if asNumber > 0 {
-		asnCounts[asNumber]++
-	}
-
-	const indent = "\t\t"
-
-	foundDiff := false
-	lines := []string{fmt.Sprintf("\nFound a potential improvement: '%s'", networkOrIP)}
-
-	if !(strings.EqualFold(correction[1], mmdbRecord.Country.IsoCode)) {
-		foundDiff = true
-		lines = append(
-			lines,
-			fmt.Sprintf(
-				"current country: '%s'%ssuggested country: '%s'",
-				mmdbRecord.Country.IsoCode,
-				indent,
-				correction[1],
-			),
-		)
-	}
-
-	if !(strings.EqualFold(correction[2], firstSubdivision)) {
-		foundDiff = true
-		lines = append(
-			lines,
-			fmt.Sprintf(
-				"current region: '%s'%ssuggested region: '%s'",
-				firstSubdivision,
-				indent,
-				correction[2],
-			),
-		)
-	}
-
-	if !(strings.EqualFold(correction[3], mmdbRecord.City.Names["en"])) {
-		foundDiff = true
-		lines = append(
-			lines,
-			fmt.Sprintf(
-				"current city: '%s'%ssuggested city: '%s'",
-				mmdbRecord.City.Names["en"],
-				indent,
-				correction[3],
-			),
-		)
-	}
-
-	// if no postal code is provided in the correction, do not report on any
-	// differences; postal codes are frequently omitted, and as of 2020-08-01 are
-	// the postal code field is considered deprecated in RFC 8805
-	if correction[4] != "" && !(strings.EqualFold(correction[4], mmdbRecord.Postal.Code)) {
-		foundDiff = true
-		lines = append(
-			lines,
-			fmt.Sprintf(
-				"current postal code: '%s'%ssuggested postal code: '%s'",
-				mmdbRecord.Postal.Code,
-				indent,
-				correction[4],
-			),
-		)
-	}
-
-	if foundDiff {
-		if asNumber > 0 {
-			lines = append(
-				lines,
-				fmt.Sprintf(
-					"AS Number: %d",
-					asNumber,
-				),
-			)
-		}
-		if asName != "" {
-			lines = append(
-				lines,
-				fmt.Sprintf(
-					"AS Name: %s",
-					asName,
-				),
-			)
-		}
-		if ispName != "" {
-			lines = append(
-				lines,
-				fmt.Sprintf(
-					"ISP Name: %s",
-					ispName,
-				),
-			)
-		}
-
-		return strings.Join(lines, "\n"+indent), nil
-	}
-	return "", nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/maxmind/mm-geofeed-verifier/verify"
 )
 
 type parseFlagsCorrectTest struct {
@@ -116,7 +118,7 @@ type processGeofeedTest struct {
 	gf string
 	db string
 	dl []string
-	c  counts
+	c  verify.Counts
 	em string
 }
 
@@ -129,9 +131,9 @@ func TestProcessGeofeed(t *testing.T) {
 				"Found a potential improvement: '2a02:ecc0::/29",
 				"current postal code: '34021'\t\tsuggested postal code: '1060'",
 			},
-			counts{
-				2,
-				2,
+			verify.Counts{
+				Total:       2,
+				Differences: 2,
 			},
 			"",
 		},
@@ -142,7 +144,7 @@ func TestProcessGeofeed(t *testing.T) {
 	for _, test := range goodTests {
 		t.Run(
 			strings.Join([]string{test.gf, test.db}, " "), func(t *testing.T) {
-				c, dl, _, err := processGeofeed(test.gf, test.db, "")
+				c, dl, _, err := verify.ProcessGeofeed(test.gf, test.db, "")
 				assert.NoError(t, err, "processGeofeed ran without error")
 				for i, s := range test.dl {
 					assert.Contains(
@@ -162,14 +164,14 @@ func TestProcessGeofeed(t *testing.T) {
 			"test_data/geofeed-missing-fields.csv",
 			"test_data/GeoIP2-City-Test.mmdb",
 			[]string{},
-			counts{},
+			verify.Counts{},
 			"saw fewer than the expected 5 fields at line 1",
 		},
 		{
 			gf: "test_data/geofeed-empty-network.csv",
 			db: "test_data/GeoIP2-City-Test.mmdb",
 			dl: []string{},
-			c:  counts{},
+			c:  verify.Counts{},
 			em: "network field is empty",
 		},
 	}
@@ -177,7 +179,7 @@ func TestProcessGeofeed(t *testing.T) {
 	for _, test := range badTests {
 		t.Run(
 			strings.Join([]string{test.gf, test.db}, " "), func(t *testing.T) {
-				_, _, _, err := processGeofeed(test.gf, test.db, "")
+				_, _, _, err := verify.ProcessGeofeed(test.gf, test.db, "")
 				assert.EqualError(
 					t,
 					err,

--- a/verify/main.go
+++ b/verify/main.go
@@ -1,0 +1,252 @@
+// Package verify provides ProcessGeofeed so that it can
+// be used by other programs.
+package verify
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"path/filepath"
+	"strings"
+
+	"github.com/TomOnTime/utfutil"
+
+	geoip2 "github.com/oschwald/geoip2-golang"
+)
+
+// Counts blah blah.
+type Counts struct {
+	Total       int
+	Differences int
+}
+
+// ProcessGeofeed attempts to validate a given geofeedFilename.
+func ProcessGeofeed(geofeedFilename, mmdbFilename, ispFilename string) (Counts, []string, map[uint]int, error) {
+	var c Counts
+	var diffLines []string
+	geofeedFH, err := utfutil.OpenFile(filepath.Clean(geofeedFilename), utfutil.UTF8)
+	if err != nil {
+		return c, diffLines, nil, err
+	}
+	defer func() {
+		if err := geofeedFH.Close(); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	db, err := geoip2.Open(filepath.Clean(mmdbFilename))
+	if err != nil {
+		return c, diffLines, nil, err
+	}
+	defer db.Close()
+
+	var ispdb *geoip2.Reader
+	if len(ispFilename) > 0 {
+		ispdb, err = geoip2.Open(filepath.Clean(ispFilename))
+		if err != nil {
+			return c, diffLines, nil, err
+		}
+		defer ispdb.Close()
+	}
+	asnCounts := make(map[uint]int)
+
+	csvReader := csv.NewReader(geofeedFH)
+	csvReader.ReuseRecord = true
+	csvReader.Comment = '#'
+	csvReader.FieldsPerRecord = -1
+	csvReader.TrimLeadingSpace = true
+
+	const expectedFieldsPerRecord = 5
+
+	rowCount := 0
+
+	for {
+		row, err := csvReader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		rowCount++
+		if err != nil {
+			return c, diffLines, asnCounts, err
+		}
+		if len(row) < expectedFieldsPerRecord {
+			return c, nil, nil, fmt.Errorf(
+				"saw fewer than the expected %d fields at line %d",
+				expectedFieldsPerRecord,
+				rowCount,
+			)
+		}
+
+		c.Total++
+		diffLine, err := verifyCorrection(row[:expectedFieldsPerRecord], db, ispdb, asnCounts)
+		if err != nil {
+			return c, diffLines, asnCounts, err
+		}
+
+		if len(diffLine) > 0 {
+			diffLines = append(diffLines, diffLine)
+			c.Differences++
+		}
+	}
+	if err != nil && !errors.Is(err, io.EOF) {
+		return c, diffLines, asnCounts, err
+	}
+	return c, diffLines, asnCounts, nil
+}
+
+func verifyCorrection(correction []string, db, ispdb *geoip2.Reader, asnCounts map[uint]int) (string, error) {
+	/*
+	   0: network (CIDR or single IP)
+	   1: ISO-3166 country code
+	   2: ISO-3166-2 region code
+	   3: city name
+	   4: postal code
+	*/
+
+	for i, v := range correction {
+		correction[i] = strings.TrimSpace(v)
+	}
+
+	networkOrIP := correction[0]
+	if networkOrIP == "" {
+		return "", errors.New("network field is empty")
+	}
+	if !(strings.Contains(networkOrIP, "/")) {
+		if strings.Contains(networkOrIP, ":") {
+			networkOrIP += "/64"
+		} else {
+			networkOrIP += "/32"
+		}
+	}
+	network, _, err := net.ParseCIDR(networkOrIP)
+	if err != nil {
+		return "", err
+	}
+
+	mmdbRecord, err := db.City(network)
+	if err != nil {
+		return "", err
+	}
+
+	firstSubdivision := ""
+	if len(mmdbRecord.Subdivisions) > 0 {
+		firstSubdivision = mmdbRecord.Subdivisions[0].IsoCode
+	}
+	// ISO-3166-2 region codes are prefixed with the ISO country code,
+	// but we accept just the region code part
+	if strings.Contains(correction[2], "-") {
+		firstSubdivision = mmdbRecord.Country.IsoCode + "-" + firstSubdivision
+	}
+
+	asNumber := uint(0)
+	asName := ""
+	ispName := ""
+	if ispdb != nil {
+		ispRecord, err := ispdb.ISP(network)
+		if err != nil {
+			return "", err
+		}
+		asNumber = ispRecord.AutonomousSystemNumber
+		asName = ispRecord.AutonomousSystemOrganization
+		ispName = ispRecord.ISP
+	}
+	if asNumber > 0 {
+		asnCounts[asNumber]++
+	}
+
+	const indent = "\t\t"
+
+	foundDiff := false
+	lines := []string{fmt.Sprintf("\nFound a potential improvement: '%s'", networkOrIP)}
+
+	if !(strings.EqualFold(correction[1], mmdbRecord.Country.IsoCode)) {
+		foundDiff = true
+		lines = append(
+			lines,
+			fmt.Sprintf(
+				"current country: '%s'%ssuggested country: '%s'",
+				mmdbRecord.Country.IsoCode,
+				indent,
+				correction[1],
+			),
+		)
+	}
+
+	if !(strings.EqualFold(correction[2], firstSubdivision)) {
+		foundDiff = true
+		lines = append(
+			lines,
+			fmt.Sprintf(
+				"current region: '%s'%ssuggested region: '%s'",
+				firstSubdivision,
+				indent,
+				correction[2],
+			),
+		)
+	}
+
+	if !(strings.EqualFold(correction[3], mmdbRecord.City.Names["en"])) {
+		foundDiff = true
+		lines = append(
+			lines,
+			fmt.Sprintf(
+				"current city: '%s'%ssuggested city: '%s'",
+				mmdbRecord.City.Names["en"],
+				indent,
+				correction[3],
+			),
+		)
+	}
+
+	// if no postal code is provided in the correction, do not report on any
+	// differences; postal codes are frequently omitted, and as of 2020-08-01 are
+	// the postal code field is considered deprecated in RFC 8805
+	if correction[4] != "" && !(strings.EqualFold(correction[4], mmdbRecord.Postal.Code)) {
+		foundDiff = true
+		lines = append(
+			lines,
+			fmt.Sprintf(
+				"current postal code: '%s'%ssuggested postal code: '%s'",
+				mmdbRecord.Postal.Code,
+				indent,
+				correction[4],
+			),
+		)
+	}
+
+	if foundDiff {
+		if asNumber > 0 {
+			lines = append(
+				lines,
+				fmt.Sprintf(
+					"AS Number: %d",
+					asNumber,
+				),
+			)
+		}
+		if asName != "" {
+			lines = append(
+				lines,
+				fmt.Sprintf(
+					"AS Name: %s",
+					asName,
+				),
+			)
+		}
+		if ispName != "" {
+			lines = append(
+				lines,
+				fmt.Sprintf(
+					"ISP Name: %s",
+					ispName,
+				),
+			)
+		}
+
+		return strings.Join(lines, "\n"+indent), nil
+	}
+	return "", nil
+}


### PR DESCRIPTION
Moved `ProcessGeofeed` to `verify` sub-package to facilitate use of mm-geofeed-verifier as an external module in a geofeed-verifier.