### PR TITLE
Remove goreleaser replacements

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,12 +6,6 @@ builds:
 archives:
     -
       wrap_in_directory: true
-      replacements:
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-          386: i386
-          amd64: x86_64
       files:
           - CHANGELOG.md
           - LICENSE-APACHE


### PR DESCRIPTION
As of v1.19.0, goreleaser [no longer supports](https://goreleaser.com/deprecations/#archivesreplacements) replacements. Removing these from `goreleaser.yml` allows the build to succeed.