### PR TITLE
Clarify options in dev release script

### DIFF
--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -37,7 +37,7 @@ echo "$version"
 echo $'\nRelease notes:'
 echo "$notes"
 
-read -e -p "Push to origin? " should_push
+read -e -p "Push to origin? (y/n) " should_push
 
 if [ "$should_push" != "y" ]; then
     echo "Aborting"


### PR DESCRIPTION
When running the release script, the user is asked whether they want to 'push to origin'. The only positive answer is `y` — `yes`, `Y`, Enter, etc are interpreted as a 'no'. In this PR, I've clarified that the answer we're looking for is `y`.