### PR TITLE
Require geofeeds to have content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## CHANGELOG
 
+## 3.1.0 (2024-11-05)
+
+* Empty geofeeds will now be considered invalid, unless the (new) EmptyOK option
+  is passed to ProcessGeofeed (e.g. via the new `empty-ok` flag).
+
 ## 3.0.0 (2024-08-14)
 
 * Update interface of ProcessGeofeed in the verifier package, adding a new

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ type config struct {
 	db      string
 	isp     string
 	laxMode bool
+	emptyOK bool
 }
 
 func main() {
@@ -50,7 +51,7 @@ func run() error {
 		conf.gf,
 		conf.db,
 		conf.isp,
-		verify.Options{LaxMode: conf.laxMode},
+		verify.Options{LaxMode: conf.laxMode, EmptyOK: conf.emptyOK},
 	)
 	if err != nil {
 		if errors.Is(err, verify.ErrInvalidGeofeed) {
@@ -108,6 +109,11 @@ func parseFlags(program string, args []string) (c *config, output string, err er
 		"lax",
 		false,
 		"Enable lax mode: geofeed's region code may be provided without country code prefix")
+	flags.BoolVar(
+		&conf.emptyOK,
+		"empty-ok",
+		false,
+		"Allow empty geofeeds to be considered valid")
 
 	err = flags.Parse(args)
 	if err != nil {

--- a/verify/errors.go
+++ b/verify/errors.go
@@ -2,9 +2,14 @@ package verify
 
 import "errors"
 
-// ErrInvalidGeofeed represents error that is returned in case of incomplete compliance
-// with RFC 8805 standards and the mode in which the program is run.
-var ErrInvalidGeofeed = errors.New("geofeed does not comply with the RFC 8805 standards")
+var (
+	// ErrInvalidGeofeed represents error that is returned in case of incomplete
+	// compliance with RFC 8805 standards and the mode in which the program is
+	// run.
+	ErrInvalidGeofeed = errors.New("geofeed does not comply with the RFC 8805 standards")
+	// ErrEmptyGeofeed indicates a Geofeed with no records.
+	ErrEmptyGeofeed = errors.New("geofeed is empty")
+)
 
 // RowInvalidity represents type of row invalidity.
 type RowInvalidity int

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -47,6 +47,9 @@ type Options struct {
 	// from appearing in error messages. This reduces information leakage in
 	// contexts where the error messages might be shared.
 	HideFilePathsInErrorMessages bool
+	// EmptyOK, if set to true, will consider a geofeed with no records to be
+	// valid. The default behavior (false) requires a geofeed to not be empty.
+	EmptyOK bool
 }
 
 // ProcessGeofeed attempts to validate a given geofeedFilename.
@@ -155,6 +158,10 @@ func ProcessGeofeed(
 			return c, diffLines, asnCounts, fmt.Errorf("error reading file: %w", err)
 		}
 		return c, diffLines, asnCounts, fmt.Errorf("error while reading %s: %w", geofeedFilename, err)
+	}
+
+	if c.Total == 0 && !opts.EmptyOK {
+		return c, diffLines, asnCounts, ErrEmptyGeofeed
 	}
 
 	if c.Invalid > 0 || len(c.SampleInvalidRows) > 0 {


### PR DESCRIPTION
Generally, a geofeed with no content should not be considered valid. In this PR, I've updated the verified to consider empty geofeeds invalid by default. A new flag & option preserves the previous behaviour for anybody who needs backwards-compatibility. Note that a new error has been added (`ErrEmptyGeofeed`), since our processing expects `ErrInvalidGeofeed` to have been triggered by invalid records.