### PR TITLE
Make the MMDB optional for format-only validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,49 @@
 ## mm-geofeed-verifier
 
 mm-geofeed-verifier attempts to validate that a given file follows the format
-suggested at https://datatracker.ietf.org/doc/html/rfc8805, and makes some
-comparisons to a given MMDB, typically the latest available GeoIP2-City.mmdb
+suggested at https://datatracker.ietf.org/doc/html/rfc8805. Optionally, it can
+also compare the corrections against a given MMDB, typically the latest
+available GeoIP2-City.mmdb, reporting on how many differ from the current
+mappings.
 
 ## Usage
+
+#### Format validation only
+
+Run with just `-gf` to validate the geofeed's RFC 8805 format. No database is
+needed:
+
+`mm-geofeed-verifier -gf /path/to/geofeed-formatted-file`
+
+#### Comparing against an MMDB
+
+Pass `-db` to additionally compare each correction against that MMDB and report
+differences:
+
+`mm-geofeed-verifier -gf /path/to/geofeed-formatted-file -db /path/to/Database.mmdb`
 
 #### Default strict mode
 
 By default strict mode requires exact ISO-3166-2 format compliance for region
 codes:
 
-`mm-geofeed-verifier -gf /path/to/geofeed-formatted-file -db /path/to/Database.mmdb`
+`mm-geofeed-verifier -gf /path/to/geofeed-formatted-file`
 
 #### Lax mode
 
 Use `--lax` mode to allow region codes to be provided without ISO-3166 country
 code prefix:
 
-`mm-geofeed-verifier --lax -gf /path/to/geofeed-formatted-file -db /path/to/Database.mmdb`
+`mm-geofeed-verifier --lax -gf /path/to/geofeed-formatted-file`
+
+#### ISP details in comparison output
+
+Pass `-isp <path>` with an ISP MMDB to augment comparison output with AS number,
+AS organization, and ISP name for rows that differ. It is only meaningful
+together with `-db`; in format-only mode it is ignored (the tool prints a notice
+to stderr):
+
+`mm-geofeed-verifier -gf /path/to/geofeed-formatted-file -db /path/to/Database.mmdb -isp /path/to/ISP.mmdb`
 
 ## Installation and release
 

--- a/main.go
+++ b/main.go
@@ -48,6 +48,10 @@ func run() error {
 		return err
 	}
 
+	if conf.db == "" && conf.isp != "" {
+		fmt.Fprintln(os.Stderr, "-isp is ignored without -db")
+	}
+
 	c, diffLines, asnCounts, err := verify.ProcessGeofeed(
 		conf.gf,
 		conf.db,
@@ -66,6 +70,14 @@ func run() error {
 			}
 		}
 		return fmt.Errorf("unable to process geofeed %s: %w", conf.gf, err)
+	}
+
+	if conf.db == "" {
+		fmt.Printf(
+			"Validated %d rows. No MMDB provided (-db), so comparison was skipped.\n",
+			c.Total,
+		)
+		return nil
 	}
 
 	fmt.Printf(
@@ -104,8 +116,8 @@ func parseFlags(program string, args []string) (c *config, output string, err er
 	flags.StringVar(
 		&conf.db,
 		"db",
-		"/usr/local/share/GeoIP/GeoIP2-City.mmdb",
-		"Path to MMDB file to compare geofeed file against",
+		"",
+		"Path to MMDB file to compare the geofeed against (optional; if omitted, only the geofeed format is validated)",
 	)
 	displayVersion := false
 	flags.BoolVar(&displayVersion, "V", false, "Display version")
@@ -131,19 +143,9 @@ func parseFlags(program string, args []string) (c *config, output string, err er
 		os.Exit(0)
 	}
 
-	if conf.gf == "" && conf.db == "" {
-		flags.PrintDefaults()
-		return nil, buf.String(), errors.New(
-			"-gf is required and -db can not be an empty string",
-		)
-	}
 	if conf.gf == "" {
 		flags.PrintDefaults()
 		return nil, buf.String(), errors.New("-gf is required")
-	}
-	if conf.db == "" {
-		flags.PrintDefaults()
-		return nil, buf.String(), errors.New("-db is required")
 	}
 
 	return &conf, buf.String(), nil

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,7 @@ func TestParseFlagsCorrect(t *testing.T) {
 			[]string{"-gf", "geofeed.csv"},
 			config{
 				gf: "geofeed.csv",
-				db: "/usr/local/share/GeoIP/GeoIP2-City.mmdb",
+				db: "",
 			},
 		},
 		{
@@ -100,19 +100,9 @@ func TestParseFlagsError(t *testing.T) {
 			"-gf is required",
 		},
 		{
-			[]string{"-db", ""},
-			"Path to local geofeed file",
-			"-gf is required and -db can not be an empty string",
-		},
-		{
 			[]string{"-db", "file.mdb"},
 			"Path to local geofeed file",
 			"-gf is required",
-		},
-		{
-			[]string{"-gf", "geofeed.csv", "-db", ""},
-			"Path to local geofeed file",
-			"-db is required",
 		},
 	}
 

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -59,7 +59,7 @@ func ProcessGeofeed(
 	mmdbFilename,
 	ispFilename string,
 	opts Options,
-) (CheckResult, []string, map[uint]int, error) { //nolint:unparam // false positive on map[uint]int
+) (CheckResult, []string, map[uint]int, error) {
 	c := NewCheckResult()
 	var diffLines []string
 
@@ -78,25 +78,31 @@ func ProcessGeofeed(
 		return c, diffLines, nil, ErrNotUTF8
 	}
 
-	db, err := maxminddb.Open(filepath.Clean(mmdbFilename))
-	if err != nil {
-		if opts.HideFilePathsInErrorMessages {
-			return c, diffLines, nil, fmt.Errorf("unable to open MMDB: %w", err)
-		}
-		return c, diffLines, nil, fmt.Errorf("unable to open MMDB %s: %w", mmdbFilename, err)
-	}
-	defer db.Close()
-
-	var ispdb *maxminddb.Reader
-	if ispFilename != "" {
-		ispdb, err = maxminddb.Open(filepath.Clean(ispFilename))
+	var db, ispdb *maxminddb.Reader
+	if mmdbFilename != "" {
+		db, err = maxminddb.Open(filepath.Clean(mmdbFilename))
 		if err != nil {
 			if opts.HideFilePathsInErrorMessages {
-				return c, diffLines, nil, fmt.Errorf("unable to open ISP MMDB: %w", err)
+				return c, diffLines, nil, fmt.Errorf("unable to open MMDB: %w", err)
 			}
-			return c, diffLines, nil, fmt.Errorf("unable to open ISP MMDB %s: %w", ispFilename, err)
+			return c, diffLines, nil, fmt.Errorf("unable to open MMDB %s: %w", mmdbFilename, err)
 		}
-		defer ispdb.Close()
+		defer db.Close()
+
+		if ispFilename != "" {
+			ispdb, err = maxminddb.Open(filepath.Clean(ispFilename))
+			if err != nil {
+				if opts.HideFilePathsInErrorMessages {
+					return c, diffLines, nil, fmt.Errorf("unable to open ISP MMDB: %w", err)
+				}
+				return c, diffLines, nil, fmt.Errorf(
+					"unable to open ISP MMDB %s: %w",
+					ispFilename,
+					err,
+				)
+			}
+			defer ispdb.Close()
+		}
 	}
 	asnCounts := map[uint]int{}
 
@@ -234,6 +240,25 @@ func verifyCorrection(
 			valid:            false,
 			invalidityType:   UnableToParseNetwork,
 			invalidityReason: fmt.Sprintf("unable to parse network %s: %s", networkOrIP, err),
+		}
+	}
+
+	if db == nil {
+		// format-only mode: only the DB-independent region-code format rule applies.
+		if !strings.Contains(correction[2], "-") && correction[2] != "" && !opts.LaxMode {
+			return "", verificationResult{
+				valid:          false,
+				invalidityType: InvalidRegionCode,
+				invalidityReason: fmt.Sprintf(
+					"invalid ISO 3166-2 region code format in strict (default) mode, row: '%s'",
+					strings.Join(correction, ","),
+				),
+			}
+		}
+		return "", verificationResult{
+			valid:            true,
+			invalidityType:   RowInvalidity(-1),
+			invalidityReason: "",
 		}
 	}
 

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -198,6 +198,17 @@ type verificationResult struct {
 	invalidityReason string
 }
 
+func invalidRegionCodeResult(correction []string) verificationResult {
+	return verificationResult{
+		valid:          false,
+		invalidityType: InvalidRegionCode,
+		invalidityReason: fmt.Sprintf(
+			"invalid ISO 3166-2 region code format in strict (default) mode, row: '%s'",
+			strings.Join(correction, ","),
+		),
+	}
+}
+
 func verifyCorrection(
 	correction []string,
 	db, ispdb *maxminddb.Reader,
@@ -246,14 +257,7 @@ func verifyCorrection(
 	if db == nil {
 		// format-only mode: only the DB-independent region-code format rule applies.
 		if !strings.Contains(correction[2], "-") && correction[2] != "" && !opts.LaxMode {
-			return "", verificationResult{
-				valid:          false,
-				invalidityType: InvalidRegionCode,
-				invalidityReason: fmt.Sprintf(
-					"invalid ISO 3166-2 region code format in strict (default) mode, row: '%s'",
-					strings.Join(correction, ","),
-				),
-			}
+			return "", invalidRegionCodeResult(correction)
 		}
 		return "", verificationResult{
 			valid:            true,
@@ -327,14 +331,7 @@ func verifyCorrection(
 	if strings.Contains(correction[2], "-") {
 		mostSpecificSubdivision = countryCode + "-" + mostSpecificSubdivision
 	} else if correction[2] != "" && !opts.LaxMode {
-		return "", verificationResult{
-			valid:          false,
-			invalidityType: InvalidRegionCode,
-			invalidityReason: fmt.Sprintf(
-				"invalid ISO 3166-2 region code format in strict (default) mode, row: '%s'",
-				strings.Join(correction, ","),
-			),
-		}
+		return "", invalidRegionCodeResult(correction)
 	}
 
 	asNumber := uint(0)

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -276,6 +276,21 @@ func TestProcessGeofeed_FormatOnly(t *testing.T) {
 		assert.Equal(t, 0, c.Differences, "expected no differences")
 	})
 
+	t.Run("lax mode accepts non-prefixed region codes, format-only", func(t *testing.T) {
+		c, dl, asnCounts, err := ProcessGeofeed(
+			"test_data/geofeed-valid-lax.csv",
+			"",
+			"",
+			Options{LaxMode: true},
+		)
+		require.NoError(t, err, "processGeofeed ran without error in lax format-only mode")
+		assert.Equal(t, 3, c.Total, "expected total rows")
+		assert.Equal(t, 0, c.Invalid, "expected no invalid rows in lax mode")
+		assert.Equal(t, 0, c.Differences, "expected no differences")
+		assert.Empty(t, dl, "expected no diff lines")
+		assert.Empty(t, asnCounts, "expected no asn counts")
+	})
+
 	t.Run("empty mmdb path opens no DB", func(t *testing.T) {
 		_, _, _, err := ProcessGeofeed(
 			"test_data/geofeed-valid.csv",

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -226,6 +226,77 @@ func TestProcessGeofeed_Invalid(t *testing.T) {
 	}
 }
 
+func TestProcessGeofeed_FormatOnly(t *testing.T) {
+	t.Run("valid feed, format-only", func(t *testing.T) {
+		c, dl, asnCounts, err := ProcessGeofeed(
+			"test_data/geofeed-valid.csv",
+			"",
+			"",
+			Options{},
+		)
+		require.NoError(t, err, "processGeofeed ran without error")
+		assert.Equal(t, 3, c.Total, "expected total rows")
+		assert.Equal(t, 0, c.Differences, "expected no differences")
+		assert.Equal(t, 0, c.Invalid, "expected no invalid rows")
+		assert.Empty(t, dl, "expected no diff lines")
+		assert.Empty(t, asnCounts, "expected no asn counts")
+	})
+
+	t.Run("malformed feed, format-only", func(t *testing.T) {
+		c, _, _, err := ProcessGeofeed(
+			"test_data/geofeed-invalid-missing-fields.csv",
+			"",
+			"",
+			Options{},
+		)
+		require.ErrorIs(t, err, ErrInvalidGeofeed, "got expected error")
+		assert.Contains(
+			t,
+			c.SampleInvalidRows,
+			FewerFieldsThanExpected,
+			"expected a FewerFieldsThanExpected entry",
+		)
+	})
+
+	t.Run("bad region code in strict mode, format-only", func(t *testing.T) {
+		c, _, _, err := ProcessGeofeed(
+			"test_data/geofeed-valid-lax.csv",
+			"",
+			"",
+			Options{LaxMode: false},
+		)
+		require.ErrorIs(t, err, ErrInvalidGeofeed, "got expected error")
+		assert.Contains(
+			t,
+			c.SampleInvalidRows,
+			InvalidRegionCode,
+			"expected an InvalidRegionCode entry",
+		)
+		assert.Equal(t, 2, c.Invalid, "expected two invalid rows")
+		assert.Equal(t, 0, c.Differences, "expected no differences")
+	})
+
+	t.Run("empty mmdb path opens no DB", func(t *testing.T) {
+		_, _, _, err := ProcessGeofeed(
+			"test_data/geofeed-valid.csv",
+			"",
+			"",
+			Options{},
+		)
+		require.NoError(t, err, "processGeofeed ran without error when mmdbFilename is empty")
+	})
+
+	t.Run("missing mmdb path still errors", func(t *testing.T) {
+		_, _, _, err := ProcessGeofeed(
+			"test_data/geofeed-valid.csv",
+			"test_data/does-not-exist.mmdb",
+			"",
+			Options{},
+		)
+		require.Error(t, err, "processGeofeed errors when a non-empty mmdbFilename does not exist")
+	})
+}
+
 func TestProcessGeofeed_NonUTF8(t *testing.T) {
 	tests := []struct {
 		gf   string


### PR DESCRIPTION
## What

Makes the MaxMind City MMDB optional. With no `-db`, `mm-geofeed-verifier`
validates a geofeed's RFC 8805 format only — field count, empty-network,
network parseability, and strict/lax region-code format — and skips the
database comparison. Passing `-db <path>` keeps the existing behavior of
comparing corrections against the MMDB.

Implemented as an empty-string sentinel in `verify.ProcessGeofeed`:
`mmdbFilename == ""` selects format-only mode. The library signature, the
`Options`/`CheckResult` types, and the error sentinels are unchanged, and the
with-`db` code path is untouched — so existing behavior is byte-for-byte
identical when a database is supplied.

## Changes

- **verify**: skip opening the City and ISP MMDBs when `mmdbFilename == ""`;
  in that mode run only the DB-independent row checks and return empty diff and
  ASN-count results.
- **CLI**: `-db` now defaults to `""`, so only `-gf` is required. Format-only
  runs print a "comparison skipped" summary; `-isp` supplied without `-db`
  prints a one-line stderr notice (it only augments comparison output).
- **Docs**: README now documents format-only validation as the default,
  `-db` comparison as opt-in, and the previously-undocumented `-isp` flag.
- **Tests**: added format-only coverage in `verify_test.go`; updated the flag
  tests in `main_test.go` for the new `-db` default.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **format validation only** mode (`-gf`) that runs without an MMDB.
  * Added **optional MMDB comparison** mode (`-db` together with `-gf`), including region-code checks.
  * Added **strict vs lax** region-code format behavior.
  * Added **ISP details** in comparison output (`-isp`) when MMDB comparison is enabled.
* **Bug Fixes**
  * Now warns when `-isp` is used without MMDB comparison and treats absent MMDB as format-only.
* **Documentation**
  * Updated README with new modes, clearer help/validation behavior, and command examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->